### PR TITLE
Fix upgrade panel and wizard projectile

### DIFF
--- a/src/components/GameHUD.tsx
+++ b/src/components/GameHUD.tsx
@@ -38,13 +38,16 @@ const GameHUD: React.FC = () => {
       cardCountDecreased: currentCount < prevUpgradeCardCount.current
     });
     
-    if (showUpgradePanel && currentCount < prevUpgradeCardCount.current) {
+    if (
+      showUpgradePanel &&
+      (currentCount < prevUpgradeCardCount.current || player?.hasSelectedUpgrade)
+    ) {
       // An upgrade was applied, close the panel
-      console.log('GameHUD: Closing upgrade panel due to card count decrease');
+      console.log('GameHUD: Closing upgrade panel after upgrade selection');
       setShowUpgradePanel(false);
     }
     prevUpgradeCardCount.current = currentCount;
-  }, [player?.upgradeCards?.length, showUpgradePanel]);
+  }, [player?.upgradeCards?.length, player?.hasSelectedUpgrade, showUpgradePanel]);
 
   // Force close upgrade panel function
   const forceCloseUpgradePanel = React.useCallback(() => {
@@ -54,7 +57,13 @@ const GameHUD: React.FC = () => {
 
   // Pulsing animation for upgrade button
   React.useEffect(() => {
-    if (gameState?.phase === 'post-combat' && player?.upgradeCards && player.upgradeCards.length > 0 && !showUpgradePanel) {
+    if (
+      gameState?.phase === 'post-combat' &&
+      player?.upgradeCards &&
+      player.upgradeCards.length > 0 &&
+      !player?.hasSelectedUpgrade &&
+      !showUpgradePanel
+    ) {
       const pulseAnimation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
@@ -74,7 +83,7 @@ const GameHUD: React.FC = () => {
     } else {
       pulseAnim.setValue(1);
     }
-  }, [gameState?.phase, player?.upgradeCards, showUpgradePanel, pulseAnim]);
+  }, [gameState?.phase, player?.upgradeCards, player?.hasSelectedUpgrade, showUpgradePanel, pulseAnim]);
 
   if (!gameState || !player) {
     return null;
@@ -248,7 +257,11 @@ const GameHUD: React.FC = () => {
       </View>
       
       {/* Bottom Right Upgrade Button */}
-      {gameState.phase === 'post-combat' && player?.upgradeCards && player.upgradeCards.length > 0 && !showUpgradePanel && (
+      {gameState.phase === 'post-combat' &&
+        player?.upgradeCards &&
+        player.upgradeCards.length > 0 &&
+        !player.hasSelectedUpgrade &&
+        !showUpgradePanel && (
         <Animated.View style={[styles.bottomRightUpgradeButton, { transform: [{ scale: pulseAnim }] }]}>
           <TouchableOpacity
             style={styles.bottomRightUpgradeButtonInner}

--- a/src/game/scenes/MainScene.ts
+++ b/src/game/scenes/MainScene.ts
@@ -1066,131 +1066,51 @@ export default class MainScene extends Phaser.Scene {
   }
 
   private createWizardProjectile(attacker: Unit, allUnits: Unit[]) {
-    console.log(`🧙 Creating wizard projectile for ${attacker.name} (${attacker.id})`);
-    
-    // Check if attacker has a valid position
-    if (!attacker.position) {
-      console.log(`❌ Wizard ${attacker.id} has no position`);
-      return;
-    }
-    
-    // Find the closest enemy unit as the target
-    const isPlayerUnit = this.gameState?.players.some(p => 
+    if (!attacker.position) return;
+
+    const isPlayerUnit = this.gameState?.players.some(p =>
       p.units.some(u => u.id === attacker.id)
     ) || false;
-    
+
     const enemies = allUnits.filter(u => {
-      const isEnemy = isPlayerUnit ? 
-        this.gameState?.enemyUnits.some(e => e.id === u.id) :
-        this.gameState?.players.some(p => p.units.some(pu => pu.id === u.id));
+      const isEnemy = isPlayerUnit
+        ? this.gameState?.enemyUnits.some(e => e.id === u.id)
+        : this.gameState?.players.some(p => p.units.some(pu => pu.id === u.id));
       return isEnemy && u.status !== 'dead' && u.position;
     });
-    
-    console.log(`🎯 Found ${enemies.length} potential targets for wizard`);
-    
-    if (enemies.length === 0) {
-      console.log(`❌ No valid targets for wizard projectile`);
-      return;
-    }
-    
-    // Find closest enemy
+
+    if (enemies.length === 0) return;
+
     let closestEnemy: Unit | null = null;
     let closestDistance = Infinity;
-    
     for (const enemy of enemies) {
       if (!enemy.position) continue;
-      const distance = Math.abs(enemy.position.x - attacker.position.x) + 
-                      Math.abs(enemy.position.y - attacker.position.y);
+      const distance = Math.abs(enemy.position.x - attacker.position.x) +
+        Math.abs(enemy.position.y - attacker.position.y);
       if (distance < closestDistance) {
         closestDistance = distance;
         closestEnemy = enemy;
       }
     }
-    
-    if (!closestEnemy || !closestEnemy.position) {
-      console.log(`❌ No closest enemy found for wizard projectile`);
-      return;
-    }
-    
-    console.log(`🎯 Wizard targeting ${closestEnemy.name} at (${closestEnemy.position.x}, ${closestEnemy.position.y})`);
-    
-    // Get world positions
+
+    if (!closestEnemy || !closestEnemy.position) return;
+
     const startPos = this.grid.gridToWorld(attacker.position.x, attacker.position.y);
     const targetPos = this.grid.gridToWorld(closestEnemy.position.x, closestEnemy.position.y);
-    
-    console.log(`🚀 Creating projectile from (${startPos.x}, ${startPos.y}) to (${targetPos.x}, ${targetPos.y})`);
-    
-    // Create a bright, visible blue circle projectile
-    const projectile = this.add.circle(startPos.x, startPos.y - 20, 15, 0x3366ff, 1);
-    projectile.setDepth(1000); // High depth to ensure visibility
-    
-    // Add bright glow effect
-    const glowCircle = this.add.circle(startPos.x, startPos.y - 20, 25, 0x6699ff, 0.7);
-    glowCircle.setDepth(999);
-    
-    // Add white core for better visibility
-    const coreCircle = this.add.circle(startPos.x, startPos.y - 20, 8, 0xffffff, 1);
-    coreCircle.setDepth(1001);
-    
-    console.log(`✨ Created wizard projectile visual elements`);
-    
-    // Play wizard sound effect if available
-    if (this.sound.get('wizardSound')) {
-      this.sound.play('wizardSound', { volume: 0.4 });
-      console.log(`🔊 Playing wizard sound`);
-    } else {
-      console.log(`🔇 Wizard sound not available`);
-    }
-    
-    // Animate projectile to target
-    const distance = Phaser.Math.Distance.Between(startPos.x, startPos.y, targetPos.x, targetPos.y);
-    const duration = Math.max(500, distance * 3); // Slower for better visibility
-    
-    console.log(`⏱️ Projectile will travel ${distance} pixels in ${duration}ms`);
-    
-    this.tweens.add({
-      targets: [projectile, glowCircle, coreCircle],
-      x: targetPos.x,
-      y: targetPos.y - 20,
-      duration: duration,
-      ease: 'Power2',
-      onComplete: () => {
-        console.log(`💥 Wizard projectile reached target`);
-        
-        // Create bright impact effect
-        const impact = this.add.circle(targetPos.x, targetPos.y - 20, 10, 0xffffff, 1);
-        impact.setDepth(1002);
-        
-        // Create expanding ring effect
-        const ring = this.add.circle(targetPos.x, targetPos.y - 20, 5, 0x3366ff, 0.8);
-        ring.setDepth(1001);
-        
-        this.tweens.add({
-          targets: impact,
-          scale: 4,
-          alpha: 0,
-          duration: 400,
-          onComplete: () => impact.destroy()
-        });
-        
-        this.tweens.add({
-          targets: ring,
-          scale: 6,
-          alpha: 0,
-          duration: 600,
-          onComplete: () => ring.destroy()
-        });
-        
-        // Clean up projectile
-        projectile.destroy();
-        glowCircle.destroy();
-        coreCircle.destroy();
-        
-        console.log(`🧹 Cleaned up wizard projectile`);
-      }
+
+    const projectile = new Projectile(this, {
+      startX: startPos.x,
+      startY: startPos.y - 20,
+      targetX: targetPos.x,
+      targetY: targetPos.y - 20,
+      texture: 'wizard',
+      frame: 'Charge_1_1 #10.png',
+      speed: 500,
+      scale: 1.2,
     });
-    
-    console.log(`🧙 Wizard projectile creation complete`);
+
+    projectile.setTint(0x88ccff);
+    this.projectiles.push(projectile);
   }
   
   private createProjectileForAttack(attacker: Unit, allUnits: Unit[]) {

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,3 @@
-# The upgrade panel isn't working. When a player toggles and upgrade then presses "Select Upgrade" it simply re-renders the upgrade panel. It doesn't close, it doesn't grant the player the upgrade, and the upgrade available button doesn't dissapear as it should.
-
-# The wizards' attack projectile isn't working. They should have a distinct projectile (Use anything necessary, such as a simple blue circle using Phaser capabilities) or preferably Charge_1_X.png from assets\units\wizard\wizard.json
-
-# There is no animation or indication currently present to players' client when they are moving a unit from grid cell to another grid cell. We should "Pick up" the unit sprite to indicate to the player they are moving when they click + drag. There may be an implementation in code already, but it's not working.
+- [ ] Fix upgrade panel not closing or applying upgrades when player selects an upgrade.
+- [ ] Implement proper wizard projectile using Charge_1 frames or at least a blue orb so attacks are visible.
+- [ ] Ensure drag-and-drop shows "pickup" animation when moving units between grid cells.


### PR DESCRIPTION
## Summary
- close upgrade panel once an upgrade is chosen
- hide upgrade button after using an upgrade
- simplify wizard projectile so it always shows a blue Charge_1 projectile

## Testing
- `npx tsc -p tsconfig.json` *(fails: missing react native types)*

------
https://chatgpt.com/codex/tasks/task_e_684e1f09ea8c8326b905ebc50b424b63